### PR TITLE
Default write workers to available CPUs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gs_fastcopy"
-version = "1.0-alpha3"
+version = "1.0-alpha4"
 description = "Optimized file transfer and compression for large files on Google Cloud Storage"
 readme = "README.md"
 authors = [{ name = "David Haley", email = "dchaley@gmail.com" }]


### PR DESCRIPTION
For writes, we should default the worker count to available CPUs, not Google's default 8.

This adds some smarts for Unixen systems which support schedule affinities (aka restricting available cores); otherwise, it simply defaults to available CPUs.

Fixes #10.