### PR TITLE
Intercept & silence stdout/stderr

### DIFF
--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1,7 +1,6 @@
 import gzip
-import io
 import subprocess
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import gs_fastcopy
 
@@ -20,9 +19,9 @@ def subprocess_run_mock(*args, **kwargs):
                 gzip.compress(JSON_STR) if commands[4].endswith(".gz") else JSON_STR
             )
             f.write(contents)
-        return ""
+        return subprocess.CompletedProcess(args, 0, b"", None)
     else:
-        builtin_run(*args, **kwargs)
+        return builtin_run(*args, **kwargs)
 
 
 @patch.object(gs_fastcopy.subprocess, "run", new_callable=lambda: subprocess_run_mock)


### PR DESCRIPTION
Intercepts stdout (routes to dev/null) and stderr. We hold onto stderr in case the return code is non-zero for an exception.

This exception is better than simply doing nothing … but … it's still not great! 🤦🏻 

Fixes #7 