### PR TITLE
Add optional parameter: billing project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 requires-python = ">=3.7, <3.12"
 
 [project.optional-dependencies]
-dev = ["black", "bumpver", "isort", "pip-tools", "pytest"]
+dev = ["black", "bumpver", "callee", "isort", "pip-tools", "pytest"]
 
 [project.urls]
 Homepage = "https://github.com/redwoodconsulting-io/gs-fastcopy-python"

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1,6 +1,6 @@
 import gzip
 import subprocess
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import gs_fastcopy
 
@@ -14,10 +14,11 @@ builtin_run = subprocess.run
 def subprocess_run_mock(*args, **kwargs):
     commands = args[0]
     if commands[0:3] == ["gcloud", "storage", "cp"]:
-        with open(commands[4], "wb") as f:
-            contents = (
-                gzip.compress(JSON_STR) if commands[4].endswith(".gz") else JSON_STR
-            )
+        # ugh I don't like this but I just need to skip the flag if it's there
+        # this will need to get smarter if we add more flags
+        filename = commands[6] if commands[3] == "--billing-project" else commands[4]
+        with open(filename, "wb") as f:
+            contents = gzip.compress(JSON_STR) if filename.endswith(".gz") else JSON_STR
             f.write(contents)
         return subprocess.CompletedProcess(args, 0, b"", None)
     else:
@@ -25,7 +26,7 @@ def subprocess_run_mock(*args, **kwargs):
 
 
 @patch.object(gs_fastcopy.subprocess, "run", new_callable=lambda: subprocess_run_mock)
-def test_read_no_compression(mock_run):
+def test_read_no_compression(_mock_run):
     with gs_fastcopy.read("gs://my-bucket/my-file.json") as f:
         result = f.read()
 
@@ -33,8 +34,32 @@ def test_read_no_compression(mock_run):
 
 
 @patch.object(gs_fastcopy.subprocess, "run", new_callable=lambda: subprocess_run_mock)
-def test_read_with_compression(mock_run):
+def test_read_with_compression(_mock_run):
     with gs_fastcopy.read("gs://my-bucket/my-file.json.gz") as f:
         result = f.read()
 
     assert result == JSON_STR
+
+
+@patch.object(gs_fastcopy.subprocess, "run")
+def test_read_billing_project(mock_run):
+    mock_run.side_effect = subprocess_run_mock
+
+    with gs_fastcopy.read(
+        "gs://my-bucket/my-file.json.gz", billing_project="project123"
+    ) as f:
+        _ = f.read()
+
+    mock_run.assert_any_call(
+        [
+            "gcloud",
+            "storage",
+            "cp",
+            "--billing-project",
+            "project123",
+            "gs://my-bucket/my-file.json.gz",
+            ANY,
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )


### PR DESCRIPTION
The billing project specifies which project to bill against. For example, you may be running in one project, but want to count against another project's quota & billing.

By default, gs-fastcopy uses the Application Default Credentials quota project. If unset, for buckets that have "Requester Pays" enbaled, you need to specify the parameter.

Of course, the current user needs access to that project.

Adds test dependency: `callee` for partial value matching.

Fixes #9.