### PR TITLE
Update supported python versions per upstream readme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,18 +13,17 @@ classifiers = [
     "License :: OSI Approved :: Boost Software License 1.0 (BSL-1.0)",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Development Status :: 2 - Pre-Alpha",
 ]
 keywords = ["file", "copy", "cloud", "storage", "google", "gcp"]
 dependencies = [
     "google-cloud-storage",
 ]
-requires-python = ">=3.7, <3.12"
+requires-python = ">=3.9, <=3.12"
 
 [project.optional-dependencies]
 dev = ["black", "bumpver", "callee", "isort", "pip-tools", "pytest"]


### PR DESCRIPTION
We got support for 3.12 but lost support for 3.7 and 3.8 😿 

Fixes #1 