### PR TITLE
Support relative read paths

### DIFF
--- a/gs_fastcopy/__init__.py
+++ b/gs_fastcopy/__init__.py
@@ -64,8 +64,9 @@ def read(gs_uri, billing_project=None):
             # Create a symlink to the local file, to avoid copying,
             # while reusing the decompression code. Note that we
             # add --keep to not delete the file after decompression.
+            # Note that we need the abspath to support relative uris.
             keep_archive = True
-            os.symlink(gs_uri, buffer_file_name)
+            os.symlink(os.path.abspath(gs_uri), buffer_file_name)
 
         # If necessary, decompress the file before reading.
         if buffer_file_name.endswith(".gz"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gs_fastcopy"
-version = "1.0-alpha4"
+version = "1.0-alpha6"
 description = "Optimized file transfer and compression for large files on Google Cloud Storage"
 readme = "README.md"
 authors = [{ name = "David Haley", email = "dchaley@gmail.com" }]

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1,4 +1,5 @@
 import gzip
+import os
 import subprocess
 import tempfile
 from unittest.mock import ANY, patch
@@ -41,9 +42,11 @@ def test_read_local_no_compression():
 
         with gs_fastcopy.read(tmp_file.name) as f:
             result = f.read()
+            assert result == JSON_STR
 
-        with open(tmp_file.name, "rb") as f:
-            assert result == f.read()
+        with gs_fastcopy.read(os.path.relpath(tmp_file.name)) as f:
+            result = f.read()
+            assert result == JSON_STR
 
 
 @patch.object(gs_fastcopy.subprocess, "run", new_callable=lambda: subprocess_run_mock)
@@ -61,10 +64,11 @@ def test_read_local_with_compression():
 
         with gs_fastcopy.read(tmp_file.name) as f:
             result = f.read()
+            assert result == JSON_STR
 
-        # this will also make sure the file still exists
-        with gzip.open(tmp_file.name, "rb") as f:
-            assert result == f.read()
+        with gs_fastcopy.read(os.path.relpath(tmp_file.name)) as f:
+            result = f.read()
+            assert result == JSON_STR
 
 
 @patch.object(gs_fastcopy.subprocess, "run")

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -1,4 +1,5 @@
 import gzip
+import os
 import tempfile
 from unittest.mock import ANY, patch
 
@@ -65,10 +66,22 @@ def test_write_local_no_compression():
         with open(tmp_file.name, "rb") as f:
             assert f.read() == JSON_STR
 
+        with gs_fastcopy.write(os.path.relpath(tmp_file.name)) as f:
+            f.write(JSON_STR)
+
+        with open(tmp_file.name, "rb") as f:
+            assert f.read() == JSON_STR
+
 
 def test_write_local_with_compression():
     with tempfile.NamedTemporaryFile(suffix=".gz") as tmp_file:
         with gs_fastcopy.write(tmp_file.name) as f:
+            f.write(JSON_STR)
+
+        with gzip.open(tmp_file.name, "rb") as f:
+            assert f.read() == JSON_STR
+
+        with gs_fastcopy.write(os.path.relpath(tmp_file.name)) as f:
             f.write(JSON_STR)
 
         with gzip.open(tmp_file.name, "rb") as f:


### PR DESCRIPTION
This fixes the symlink to the (corrct) absolute path. Also adds the test case for reads & writes.

Bumps the version to 1.0.alpha6